### PR TITLE
Check if ssl_cipher_list is set

### DIFF
--- a/src/ircd.c
+++ b/src/ircd.c
@@ -708,6 +708,12 @@ main(int argc, char *argv[])
 
 	if(ServerInfo.ssl_cert != NULL && ServerInfo.ssl_private_key != NULL)
 	{
+		if(ServerInfo.ssl_cipher_list == NULL)
+		{
+			ierror("no ssl cipher list specified in serverinfo block.");
+			return -4;
+		}
+
 		/* just do the rb_setup_ssl_server to validate the config */
 		if(!rb_setup_ssl_server(ServerInfo.ssl_cert, ServerInfo.ssl_private_key, ServerInfo.ssl_dh_params, ServerInfo.ssl_cipher_list))
 		{


### PR DESCRIPTION
Without this check the ircd will crash on `/rehash` if there is no `ssl_cipher_list` defined in the ServerInfo block.

The value will be used unitialized here: https://github.com/darkfasel/charybdis/blob/master/src/sslproc.c#L586

```
#1  0x0000000000436419 in send_new_ssl_certs_one (ctl=0x107b480, 
    ssl_cert=0x1079810 "etc/keys/ssl.crt", 
    ssl_private_key=0x1079990 "etc/keys/ssl.key", 
    ssl_dh_params=0x1079830 "etc/dh.pem", ssl_cipher_list=0x0) at sslproc.c:606
#2  0x0000000000437434 in send_new_ssl_certs (
    ssl_cert=0x1079810 "etc/keys/ssl.crt", 
    ssl_private_key=0x1079990 "etc/keys/ssl.key", 
    ssl_dh_params=0x1079830 "etc/dh.pem", ssl_cipher_list=0x0) at sslproc.c:662
```
